### PR TITLE
Remove unnecessary Junit dependency

### DIFF
--- a/prov/build.gradle
+++ b/prov/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile project(':core')
-  compile 'junit:junit:4.12'
 }
 
 cobertura {


### PR DESCRIPTION
The `prov` module declares the Junit library as a runtime dependency. The library is only needed for the test step during compile time - the `testCompile` dependency is already added in the top level build.gradle of the project. The runtime dependency definition can generate warnings in the end-app builds.